### PR TITLE
feat: Replace coaching pipeline with EXTRACT→ASSESS→RESPOND loop

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,149 @@
+# Plan: Extract shared UI components into `@chat-sdk-expo/ui`
+
+Part of #30
+
+## Approach
+
+Create a single `@chat-sdk-expo/ui` package containing all shared UI — from primitives (Button, Card, Text) through chat-specific components (Message, PromptInput, Conversation). Align naming with [Vercel ai-elements](https://github.com/vercel/ai-elements) where applicable.
+
+**Build strategy: Source-only (no tsup build step).** Following the [byCedric/expo-monorepo-example](https://github.com/byCedric/expo-monorepo-example) pattern used by the Expo team — `"main": "./src/index.ts"`. Metro transpiles source directly. This is the standard approach for RN UI packages in monorepos and avoids issues with JSX compilation and platform-specific files (`.native.ts`/`.web.ts`).
+
+## Package Structure
+
+```
+packages/ui/
+├── src/
+│   ├── primitives/          # Low-level UI primitives (from components/ui/)
+│   │   ├── button.tsx
+│   │   ├── card.tsx
+│   │   ├── text.tsx
+│   │   ├── input.tsx
+│   │   ├── dialog.tsx
+│   │   ├── ... (all 26 existing ui/ components)
+│   │   └── index.ts
+│   │
+│   ├── chat/                # Chat components (ai-elements naming)
+│   │   ├── conversation.tsx          # was MessageList (ai-elements: Conversation)
+│   │   ├── message.tsx               # was Message (ai-elements: Message)
+│   │   ├── prompt-input.tsx          # was PromptInput (ai-elements: PromptInput)
+│   │   ├── actions.tsx               # message actions (copy, edit, vote, regenerate)
+│   │   ├── reasoning.tsx             # was Reasoning (ai-elements: Reasoning)
+│   │   ├── markdown.tsx              # was SimpleMarkdown (renders message content)
+│   │   ├── message-editor.tsx        # inline message editing
+│   │   ├── model-selector.tsx        # model picker dialog
+│   │   ├── attachments.tsx           # was AttachmentPreview (ai-elements: Attachments)
+│   │   ├── image-preview.tsx         # image attachment display + lightbox
+│   │   ├── empty-state.tsx           # was ConversationEmptyState
+│   │   ├── reasoning-toggle.tsx      # reasoning enable/disable toggle
+│   │   └── index.ts
+│   │
+│   ├── tools/               # Tool UI components
+│   │   ├── tool.tsx                  # tool router (ai-elements: Tool)
+│   │   ├── confirmation.tsx          # approval flow (ai-elements: Confirmation)
+│   │   ├── default-tool.tsx          # fallback tool display
+│   │   ├── code-execution.tsx        # code execution results
+│   │   ├── document-tool.tsx         # document creation tool
+│   │   ├── weather-tool.tsx          # weather display
+│   │   ├── temperature-tool.tsx      # temperature display
+│   │   └── index.ts
+│   │
+│   ├── artifacts/           # Artifact viewer components
+│   │   ├── artifact-panel.tsx        # slide-in artifact panel
+│   │   ├── artifact-header.tsx       # header with version nav
+│   │   ├── code-content.tsx          # code viewer (ai-elements: CodeBlock-ish)
+│   │   ├── text-content.tsx          # text document viewer
+│   │   ├── diff-view.tsx             # side-by-side diff
+│   │   ├── document-preview.tsx      # preview component
+│   │   ├── version-footer.tsx        # restore version footer
+│   │   ├── version-navigation.tsx    # version nav controls
+│   │   └── index.ts
+│   │
+│   ├── layout/              # Layout components
+│   │   ├── side-by-side.tsx          # was SideBySideLayout
+│   │   ├── chat-history.tsx          # was ChatHistoryList
+│   │   └── index.ts
+│   │
+│   ├── toast/               # Toast/notification system
+│   │   ├── toast.tsx
+│   │   ├── toast-context.tsx
+│   │   ├── use-toast.ts
+│   │   └── index.ts
+│   │
+│   ├── hooks/               # Shared hooks
+│   │   ├── use-clipboard.ts
+│   │   ├── use-attachments.ts
+│   │   └── index.ts
+│   │
+│   └── index.ts             # Root barrel export
+│
+├── package.json
+└── tsconfig.json
+```
+
+## ai-elements Naming Alignment
+
+| ai-elements | Current name | New name in @chat-sdk-expo/ui |
+|---|---|---|
+| `Conversation` / `ConversationContent` | `MessageList` | `Conversation` |
+| `ConversationEmptyState` | `ConversationEmptyState` | `ConversationEmptyState` |
+| `Message` / `MessageContent` / `MessageResponse` | `Message` | `Message` |
+| `PromptInput` / `PromptInputTextarea` / `PromptInputSubmit` | `PromptInput` | `PromptInput` |
+| `Reasoning` / `ReasoningTrigger` / `ReasoningContent` | `Reasoning` | `Reasoning` |
+| `Attachments` / `Attachment` | `AttachmentPreview` | `Attachments` / `AttachmentPreview` |
+| `ModelSelector` | `ModelSelector` | `ModelSelector` |
+| `Tool` | `Tool` | `Tool` |
+| `Confirmation` | `Confirmation` | `Confirmation` |
+
+Note: ai-elements uses compound components (e.g. `<Message><MessageContent>...</MessageContent></Message>`). We'll keep our current single-component-with-props pattern for now since our components are React Native (not web-only), but adopt their **naming**. We can refactor to compound components later if desired.
+
+## Steps
+
+### Step 1: Create the `@chat-sdk-expo/ui` package skeleton
+
+- Create `packages/ui/package.json` (source-only, no build step)
+- Create `packages/ui/tsconfig.json` (typecheck only)
+- Create `packages/ui/src/index.ts` barrel export
+
+### Step 2: Move UI primitives
+
+- Copy all 26 components from `examples/basic-chat/components/ui/` → `packages/ui/src/primitives/`
+- Create `packages/ui/src/primitives/index.ts` barrel export
+- Adjust any internal import paths
+
+### Step 3: Move chat components
+
+- Copy identical chat components from `examples/basic-chat/components/chat/` → `packages/ui/src/chat/`
+- Rename files to match ai-elements conventions where applicable
+- Create `packages/ui/src/chat/index.ts` barrel export
+- Keep app-specific toggles (ResearchToggle, CoachingToggle) in the example apps
+
+### Step 4: Move tool components
+
+- Copy tool components → `packages/ui/src/tools/`
+- Create barrel export
+
+### Step 5: Move artifact components
+
+- Copy identical artifact components → `packages/ui/src/artifacts/`
+- Create barrel export
+- Keep app-specific renderers (TrainingBlockContent) in example apps
+
+### Step 6: Move layout, toast, and hooks
+
+- Copy SideBySideLayout, ChatHistoryList → `packages/ui/src/layout/`
+- Copy toast system → `packages/ui/src/toast/`
+- Copy shared hooks → `packages/ui/src/hooks/`
+
+### Step 7: Update example apps to import from `@chat-sdk-expo/ui`
+
+- Add `"@chat-sdk-expo/ui": "workspace:*"` to both example app package.json files
+- Update all imports in `basic-chat` to use `@chat-sdk-expo/ui`
+- Update all imports in `health-coach` to use `@chat-sdk-expo/ui`
+- Delete the now-redundant local component files from both apps
+- Verify both apps still have their app-specific components locally
+
+### Step 8: Verify
+
+- Run `pnpm install` to link the new package
+- Run typecheck across the monorepo
+- Smoke test both example apps

--- a/examples/basic-chat/lib/agents/createStatefulAgent.ts
+++ b/examples/basic-chat/lib/agents/createStatefulAgent.ts
@@ -7,7 +7,7 @@
  * Uses ToolLoopAgent with prepareStep for per-step state control.
  */
 
-import { ToolLoopAgent, stepCountIs, hasToolCall, convertToModelMessages } from 'ai';
+import { ToolLoopAgent, stepCountIs, convertToModelMessages } from 'ai';
 import type { ToolSet, StopCondition } from 'ai';
 
 import type {
@@ -100,19 +100,16 @@ export function createStatefulAgent<TStates extends string>(
     messages: [],
   };
 
-  // Build stop conditions from terminal states
+  // Build stop conditions.
+  //
+  // We intentionally do NOT add hasToolCall() conditions for terminal state
+  // tools. Terminal state tools (like createDocument in RESPOND) are side
+  // effects — the loop should continue after calling them so the LLM can
+  // generate a natural conversational response in the next step. The loop
+  // already stops when the LLM generates text without calling a tool.
+  //
+  // The step limit is the only hard stop condition.
   const stopConditions: StopCondition<typeof allTools>[] = [];
-
-  // Add tool-based stop conditions for terminal states
-  // Stop when any tool in a terminal state is called
-  for (const state of workflow.terminalStates) {
-    const stateConfig = workflow.states[state];
-    for (const toolName of stateConfig.tools) {
-      stopConditions.push(hasToolCall(toolName));
-    }
-  }
-
-  // Add step limit
   stopConditions.push(stepCountIs(workflow.maxSteps || 50));
 
   // Default model
@@ -264,15 +261,13 @@ export function createStatefulAgent<TStates extends string>(
     },
 
     async stream(params: AgentCallParams): Promise<Response> {
-      // Store initial prompt
       if (params.prompt) {
         internalContext.initialPrompt = params.prompt;
       }
+      if (params.messages) {
+        internalContext.messages = params.messages;
+      }
 
-      // Call the agent with streaming
-      // Note: prompt and messages are mutually exclusive
-      // Convert UI messages to model messages format (parts -> content)
-      // Use ignoreIncompleteToolCalls to skip orphaned tool calls without results
       const modelMessages = params.messages
         ? await convertToModelMessages(params.messages, {
             ignoreIncompleteToolCalls: true,
@@ -283,22 +278,14 @@ export function createStatefulAgent<TStates extends string>(
         ? await agent.stream({ prompt: params.prompt })
         : await agent.stream({ messages: modelMessages as any });
 
-      // If no onFinish callback, return the stream directly
       if (!params.onFinish) {
         return result.toUIMessageStreamResponse();
       }
 
-      // With onFinish callback, consume the response.messages after stream ends
-      // Use consumeStream to ensure the stream is fully processed, then get messages
       const responsePromise = result.response;
-
-      // Start consuming messages in the background
-      // Note: response.messages is only available after the stream completes
-      // Wrap in an async IIFE with try/catch since PromiseLike doesn't have .catch
       (async () => {
         try {
           const response = await responsePromise;
-          // response.messages contains the assistant and tool messages from this call
           const messages = response.messages as unknown as Message[];
           await params.onFinish!(messages);
         } catch (error) {
@@ -306,8 +293,41 @@ export function createStatefulAgent<TStates extends string>(
         }
       })();
 
-      // Return the stream immediately so client can consume it
       return result.toUIMessageStreamResponse();
+    },
+
+    async streamUI(params: AgentCallParams): Promise<ReadableStream> {
+      if (params.prompt) {
+        internalContext.initialPrompt = params.prompt;
+      }
+      if (params.messages) {
+        internalContext.messages = params.messages;
+      }
+
+      const modelMessages = params.messages
+        ? await convertToModelMessages(params.messages, {
+            ignoreIncompleteToolCalls: true,
+          })
+        : undefined;
+
+      const result = params.prompt
+        ? await agent.stream({ prompt: params.prompt })
+        : await agent.stream({ messages: modelMessages as any });
+
+      if (params.onFinish) {
+        const responsePromise = result.response;
+        (async () => {
+          try {
+            const response = await responsePromise;
+            const messages = response.messages as unknown as Message[];
+            await params.onFinish!(messages);
+          } catch (error) {
+            console.error('Error in streamUI onFinish:', error);
+          }
+        })();
+      }
+
+      return result.toUIMessageStream();
     },
 
     getContext(): WorkflowContext {

--- a/examples/basic-chat/lib/agents/types.ts
+++ b/examples/basic-chat/lib/agents/types.ts
@@ -262,6 +262,9 @@ export interface StatefulAgent<TStates extends string = string> {
   /** Stream a response (returns a Response for use with fetch-based clients) */
   stream(params: AgentCallParams): Promise<Response>;
 
+  /** Stream returning a ReadableStream (for merging into createUIMessageStream) */
+  streamUI(params: AgentCallParams): Promise<ReadableStream>;
+
   /** Get current workflow context */
   getContext(): WorkflowContext;
 

--- a/examples/health-coach/components/artifacts/TrainingBlockContent.tsx
+++ b/examples/health-coach/components/artifacts/TrainingBlockContent.tsx
@@ -2,7 +2,10 @@
  * TrainingBlockContent Component
  *
  * Custom renderer for training block artifacts.
- * Displays a vertical list of sessions grouped by day.
+ * Displays a phase → week → day → session hierarchy.
+ *
+ * Supports both the new schema (phases with dayOfWeek) and
+ * graceful fallback for old plans without phases or sparse early drafts.
  */
 
 import React, { memo, useMemo } from 'react';
@@ -13,17 +16,21 @@ import { Text } from '@chat-sdk-expo/ui/primitives';
 import type { ArtifactStatus } from '@chat-sdk-expo/ui/artifacts';
 import type {
   TrainingBlock,
+  TrainingPhase,
   TrainingWeek,
   TrainingDay,
   TrainingSession,
   SessionType,
-  TimeOfDay,
 } from '../../lib/artifacts/handlers/training-block';
 
 interface TrainingBlockContentProps {
   content: string;
   status: ArtifactStatus;
 }
+
+// =============================================================================
+// CONFIGURATION
+// =============================================================================
 
 /**
  * Session type icons and colors
@@ -36,14 +43,34 @@ const sessionTypeConfig: Record<SessionType, { icon: keyof typeof Feather.glyphM
 };
 
 /**
- * Time of day display
+ * Category badge colors
  */
-const timeOfDayLabels: Record<TimeOfDay, string> = {
-  morning: 'Morning',
-  afternoon: 'Afternoon',
-  evening: 'Evening',
-  any: '',
+const categoryColors: Record<string, string> = {
+  easy: 'bg-green-100 text-green-700',
+  tempo: 'bg-yellow-100 text-yellow-700',
+  interval: 'bg-red-100 text-red-700',
+  long: 'bg-blue-100 text-blue-700',
+  recovery: 'bg-gray-100 text-gray-600',
+  'race-pace': 'bg-purple-100 text-purple-700',
+  fartlek: 'bg-orange-100 text-orange-700',
 };
+
+/**
+ * Day of week labels
+ */
+const dayLabels: Record<string, string> = {
+  monday: 'Monday',
+  tuesday: 'Tuesday',
+  wednesday: 'Wednesday',
+  thursday: 'Thursday',
+  friday: 'Friday',
+  saturday: 'Saturday',
+  sunday: 'Sunday',
+};
+
+// =============================================================================
+// PARSE
+// =============================================================================
 
 /**
  * Parse training block JSON safely
@@ -56,24 +83,25 @@ function parseTrainingBlock(content: string): TrainingBlock | null {
   }
 }
 
-/**
- * Format date for display
- */
-function formatDate(dateStr: string): string {
-  const date = new Date(dateStr + 'T00:00:00');
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric' });
-}
+// =============================================================================
+// COMPONENTS
+// =============================================================================
 
 /**
- * Get full day of week
+ * Category badge component
  */
-function getDayOfWeek(dateStr: string): string {
-  const date = new Date(dateStr + 'T00:00:00');
-  return date.toLocaleDateString('en-US', { weekday: 'long' });
-}
+const CategoryBadge = memo(function CategoryBadge({ category }: { category: string }) {
+  const colorClasses = categoryColors[category] || 'bg-secondary text-foreground';
+
+  return (
+    <View className={`rounded-full px-2 py-0.5 ${colorClasses}`}>
+      <Text className="text-xs font-medium capitalize">{category}</Text>
+    </View>
+  );
+});
 
 /**
- * Session card component - full width for list layout
+ * Session card component
  */
 const SessionCard = memo(function SessionCard({ session }: { session: TrainingSession }) {
   const config = sessionTypeConfig[session.type] || sessionTypeConfig.run;
@@ -82,8 +110,8 @@ const SessionCard = memo(function SessionCard({ session }: { session: TrainingSe
   const successStyle = useResolveClassNames('text-green-500');
 
   return (
-    <View className={`flex-row items-center gap-3 rounded-lg bg-card p-3 ${session.completed ? 'opacity-60' : ''}`}>
-      <View className="h-10 w-10 items-center justify-center rounded-full bg-secondary">
+    <View className={`flex-row items-start gap-3 rounded-lg bg-card p-3 ${session.completed ? 'opacity-60' : ''}`}>
+      <View className="mt-0.5 h-10 w-10 items-center justify-center rounded-full bg-secondary">
         <Feather name={config.icon} size={20} color={iconStyle.color as string} />
       </View>
       <View className="flex-1">
@@ -94,16 +122,13 @@ const SessionCard = memo(function SessionCard({ session }: { session: TrainingSe
           {session.completed && (
             <Feather name="check-circle" size={16} color={successStyle.color as string} />
           )}
-        </View>
-        <View className="mt-0.5 flex-row flex-wrap items-center gap-x-3 gap-y-0.5">
-          {session.timeOfDay && session.timeOfDay !== 'any' && (
-            <View className="flex-row items-center gap-1">
-              <Feather name="clock" size={12} color={mutedStyle.color as string} />
-              <Text variant="muted" className="text-sm">
-                {timeOfDayLabels[session.timeOfDay]}
-              </Text>
-            </View>
+          {session.category && (
+            <CategoryBadge category={session.category} />
           )}
+        </View>
+
+        {/* Metadata row */}
+        <View className="mt-1 flex-row flex-wrap items-center gap-x-3 gap-y-0.5">
           {session.duration && (
             <View className="flex-row items-center gap-1">
               <Feather name="watch" size={12} color={mutedStyle.color as string} />
@@ -120,7 +145,46 @@ const SessionCard = memo(function SessionCard({ session }: { session: TrainingSe
               </Text>
             </View>
           )}
+          {session.intensity && (
+            <View className="flex-row items-center gap-1">
+              <Feather name="trending-up" size={12} color={mutedStyle.color as string} />
+              <Text variant="muted" className="text-sm">
+                {session.intensity.target}
+                {session.intensity.zone ? ` (${session.intensity.zone})` : ''}
+              </Text>
+            </View>
+          )}
         </View>
+
+        {/* Intervals */}
+        {session.intervals && (
+          <View className="mt-1.5 rounded border border-border/50 bg-secondary/30 px-2 py-1.5">
+            <Text className="text-sm font-medium">
+              {session.intervals.reps} × {session.intervals.distance} @ {session.intervals.pace}
+            </Text>
+            <Text variant="muted" className="text-xs">
+              Recovery: {session.intervals.recovery}
+            </Text>
+          </View>
+        )}
+
+        {/* Warmup/Cooldown */}
+        {(session.warmup || session.cooldown) && (
+          <View className="mt-1 flex-row gap-3">
+            {session.warmup && (
+              <Text variant="muted" className="text-xs">
+                WU: {session.warmup}
+              </Text>
+            )}
+            {session.cooldown && (
+              <Text variant="muted" className="text-xs">
+                CD: {session.cooldown}
+              </Text>
+            )}
+          </View>
+        )}
+
+        {/* Description */}
         {session.description && (
           <Text variant="muted" className="mt-1 text-sm" numberOfLines={2}>
             {session.description}
@@ -132,32 +196,24 @@ const SessionCard = memo(function SessionCard({ session }: { session: TrainingSe
 });
 
 /**
- * Day section component - header with sessions below
+ * Day section component
  */
 const DaySection = memo(function DaySection({ day }: { day: TrainingDay }) {
-  const isToday = day.date === new Date().toISOString().split('T')[0];
   const mutedStyle = useResolveClassNames('text-muted-foreground');
+  const dayLabel = day.dayOfWeek ? dayLabels[day.dayOfWeek] || day.dayOfWeek : 'Day';
 
   return (
-    <View className="mb-4">
+    <View className="mb-3">
       {/* Day header */}
-      <View className={`mb-2 flex-row items-center gap-2 px-4 ${isToday ? '' : ''}`}>
-        <Text className={`text-sm font-semibold ${isToday ? 'text-primary' : 'text-muted-foreground'}`}>
-          {getDayOfWeek(day.date)}
+      <View className="mb-1.5 flex-row items-center gap-2 px-4">
+        <Text className="text-sm font-semibold text-muted-foreground">
+          {dayLabel}
         </Text>
-        <Text className={`text-sm ${isToday ? 'text-primary' : 'text-muted-foreground'}`}>
-          {formatDate(day.date)}
-        </Text>
-        {isToday && (
-          <View className="rounded-full bg-primary px-2 py-0.5">
-            <Text className="text-xs font-medium text-primary-foreground">Today</Text>
-          </View>
-        )}
       </View>
 
       {/* Sessions */}
       <View className="gap-2 px-4">
-        {day.sessions.length === 0 ? (
+        {!day.sessions || day.sessions.length === 0 ? (
           <View className="flex-row items-center gap-2 rounded-lg bg-card/50 p-3">
             <Feather name="moon" size={16} color={mutedStyle.color as string} />
             <Text variant="muted">Rest Day</Text>
@@ -177,30 +233,120 @@ const DaySection = memo(function DaySection({ day }: { day: TrainingDay }) {
  */
 const WeekSection = memo(function WeekSection({ week }: { week: TrainingWeek }) {
   return (
-    <View className="mb-6">
+    <View className="mb-5">
       {/* Week header */}
-      <View className="mb-3 border-b border-border px-4 pb-2">
-        <Text className="text-base font-bold">
-          Week {week.weekNumber}
-        </Text>
-        {week.focus && (
-          <Text variant="muted" className="text-sm">
-            {week.focus}
+      <View className="mb-2 flex-row items-center justify-between border-b border-border px-4 pb-2">
+        <View>
+          <Text className="text-base font-bold">
+            Week {week.weekNumber}
           </Text>
+          {week.focus && (
+            <Text variant="muted" className="text-sm">
+              {week.focus}
+            </Text>
+          )}
+        </View>
+        {week.targetVolume && (
+          <View className="rounded-full bg-secondary px-2.5 py-1">
+            <Text className="text-xs font-medium text-muted-foreground">
+              {week.targetVolume}
+            </Text>
+          </View>
         )}
       </View>
 
       {/* Days */}
-      {week.days.map((day) => (
-        <DaySection key={day.date} day={day} />
+      {week.days?.map((day, index) => (
+        <DaySection key={day.dayOfWeek || `day-${index}`} day={day} />
       ))}
     </View>
   );
 });
 
 /**
+ * Phase section component
+ */
+const PhaseSection = memo(function PhaseSection({ phase, index }: { phase: TrainingPhase; index: number }) {
+  return (
+    <View className="mb-6">
+      {/* Phase header */}
+      <View className="mb-3 bg-secondary/50 px-4 py-3">
+        <Text className="text-lg font-bold">
+          {phase.name}
+        </Text>
+        {(phase.focus || phase.durationWeeks) && (
+          <Text variant="muted" className="mt-0.5">
+            {[phase.focus, phase.durationWeeks ? `${phase.durationWeeks} weeks` : null].filter(Boolean).join(' · ')}
+          </Text>
+        )}
+        {phase.weeklyVolume && (
+          <Text variant="muted" className="text-sm">
+            Volume: {phase.weeklyVolume.start} → {phase.weeklyVolume.end}
+            {phase.weeklyVolume.progression ? ` (${phase.weeklyVolume.progression})` : ''}
+          </Text>
+        )}
+        {phase.qualitySessions && (
+          <Text variant="muted" className="text-sm">
+            Quality: {phase.qualitySessions.perWeek}/week{phase.qualitySessions.types ? ` — ${phase.qualitySessions.types.join(', ')}` : ''}
+          </Text>
+        )}
+      </View>
+
+      {/* Weeks within this phase */}
+      {phase.weeks?.map((week) => (
+        <WeekSection key={week.weekNumber} week={week} />
+      ))}
+    </View>
+  );
+});
+
+/**
+ * Athlete profile header
+ */
+const AthleteProfileHeader = memo(function AthleteProfileHeader({
+  trainingBlock,
+}: {
+  trainingBlock: TrainingBlock;
+}) {
+  const profile = trainingBlock.athleteProfile;
+  if (!profile) return null;
+
+  return (
+    <View className="mb-4 rounded-lg bg-card p-4">
+      <Text className="text-sm font-semibold text-muted-foreground">Athlete Profile</Text>
+      <View className="mt-1.5 gap-1">
+        <Text className="text-sm">
+          <Text className="font-medium">Event:</Text> {profile.goalEvent}
+        </Text>
+        <Text className="text-sm">
+          <Text className="font-medium">Current:</Text> {profile.currentLevel}
+        </Text>
+        <Text className="text-sm">
+          <Text className="font-medium">Gap:</Text> {profile.gap}
+        </Text>
+        {profile.constraints && (
+          <Text className="text-sm">
+            <Text className="font-medium">Constraints:</Text> {profile.constraints}
+          </Text>
+        )}
+        {profile.notes && (
+          <Text variant="muted" className="mt-1 text-sm italic">
+            {profile.notes}
+          </Text>
+        )}
+      </View>
+    </View>
+  );
+});
+
+// =============================================================================
+// MAIN COMPONENT
+// =============================================================================
+
+/**
  * TrainingBlockContent component
- * Renders a vertical list of sessions grouped by day
+ * Renders a phase → week → day → session hierarchy.
+ * Falls back gracefully for old plans or sparse early drafts.
  */
 export const TrainingBlockContent = memo(function TrainingBlockContent({
   content,
@@ -216,21 +362,42 @@ export const TrainingBlockContent = memo(function TrainingBlockContent({
     );
   }
 
+  // Check for new schema (has phases) vs old/sparse schema
+  const hasPhases = trainingBlock.phases && trainingBlock.phases.length > 0;
+
   return (
     <ScrollView className="flex-1 bg-background" contentContainerClassName="py-4">
       {/* Header */}
-      <View className="mb-6 px-4">
+      <View className="mb-4 px-4">
         <Text className="text-xl font-bold">{trainingBlock.name}</Text>
-        <Text variant="muted" className="mt-1">{trainingBlock.goal}</Text>
-        <Text variant="muted" className="mt-1 text-sm">
-          {formatDate(trainingBlock.startDate)} – {formatDate(trainingBlock.endDate)}
-        </Text>
+        {trainingBlock.totalWeeks != null && trainingBlock.totalWeeks > 0 && (
+          <Text variant="muted" className="mt-1">
+            {trainingBlock.totalWeeks} week program
+          </Text>
+        )}
       </View>
 
-      {/* Weeks */}
-      {trainingBlock.weeks.map((week) => (
-        <WeekSection key={week.weekNumber} week={week} />
+      {/* Athlete profile */}
+      <View className="px-4">
+        <AthleteProfileHeader trainingBlock={trainingBlock} />
+      </View>
+
+      {/* Phases (new schema) */}
+      {hasPhases && trainingBlock.phases.map((phase, index) => (
+        <PhaseSection key={phase.name || `phase-${index}`} phase={phase} index={index} />
       ))}
+
+      {/* Fallback for old plans without phases or sparse drafts */}
+      {!hasPhases && (
+        <View className="px-4 py-8">
+          <View className="items-center">
+            <Feather name="loader" size={24} color="#999" />
+            <Text variant="muted" className="mt-2 text-center">
+              Plan is being developed...
+            </Text>
+          </View>
+        </View>
+      )}
     </ScrollView>
   );
 });

--- a/examples/health-coach/components/chat/Tool.tsx
+++ b/examples/health-coach/components/chat/Tool.tsx
@@ -22,7 +22,14 @@ export function Tool({ part, onApprovalResponse }: ToolProps) {
 
   // Support both new format (args/result) and legacy format (input/output)
   const args = part.args || part.input;
-  const result = part.result || part.output;
+  const rawResult = part.result || part.output;
+
+  // AI SDK v6 wraps tool results as { type: "json", value: { ... } } when state is
+  // "output-available". Unwrap to give tool components direct access to the result data.
+  const result =
+    rawResult && typeof rawResult === 'object' && 'type' in rawResult && 'value' in rawResult
+      ? (rawResult as { type: string; value: unknown }).value
+      : rawResult;
 
   // Handle approval states
   if (state === 'approval-requested') {

--- a/examples/health-coach/components/chat/tools/DocumentTool.tsx
+++ b/examples/health-coach/components/chat/tools/DocumentTool.tsx
@@ -13,6 +13,7 @@ import { Text } from '@chat-sdk-expo/ui/primitives';
 import { useArtifact } from '../../../contexts/ArtifactContext';
 import { CodeContent } from '@chat-sdk-expo/ui/artifacts';
 import { TextContent } from '@chat-sdk-expo/ui/artifacts';
+import { authFetch } from '../../../lib/auth/client';
 import type { ToolUIProps } from './types';
 import type { ArtifactKind } from '../../../lib/artifacts/types';
 
@@ -122,7 +123,7 @@ export const DocumentTool = memo(function DocumentTool({
     if (documentId) {
       setIsLoading(true);
       try {
-        const response = await fetch(`/api/documents/${documentId}`);
+        const response = await authFetch(`/api/documents/${documentId}`);
         if (response.ok) {
           const doc = await response.json();
           setArtifact({

--- a/examples/health-coach/lib/agents/models.ts
+++ b/examples/health-coach/lib/agents/models.ts
@@ -5,8 +5,64 @@
  */
 
 import { createAnthropic } from '@ai-sdk/anthropic';
+import { wrapLanguageModel } from 'ai';
+import type { LanguageModelMiddleware } from 'ai';
 import { MODEL_SHORTHAND_MAP } from '../ai/models';
 import type { ModelShorthand, ModelConfig } from './types';
+
+/**
+ * Middleware that sanitizes stringified tool-call inputs.
+ *
+ * Bug: The AI SDK's LanguageModelV3 spec defines tool-call input as `string`
+ * (stringified JSON). During multi-step agent execution, previous steps' tool
+ * calls are included in the message history with `input: string`. The Anthropic
+ * provider passes `part.input` directly to the API without parsing, but the
+ * Anthropic API requires `input` to be a parsed object. This middleware parses
+ * string inputs before they reach the provider.
+ */
+const sanitizeToolInputsMiddleware: LanguageModelMiddleware = {
+  specificationVersion: 'v3',
+  transformParams: async ({ params }) => {
+    if (!params.prompt) return params;
+
+    let fixCount = 0;
+
+    const result = {
+      ...params,
+      prompt: params.prompt.map((msg, msgIdx) => {
+        if (msg.role !== 'assistant' || !Array.isArray(msg.content)) return msg;
+        return {
+          ...msg,
+          content: msg.content.map((part: any, partIdx) => {
+            // Fix any part type that has a string `input` field — the Anthropic API
+            // requires `input` to be a parsed object for tool_use blocks. This covers
+            // both 'tool-call' (AI SDK v3 format) and any other format the SDK uses.
+            if (typeof part.input === 'string' && (part.type === 'tool-call' || part.type === 'tool_use' || part.toolName)) {
+              fixCount++;
+              const toolId = part.toolName || part.name || 'unknown';
+              console.warn(`[middleware] Fixing ${part.type} string input at msg[${msgIdx}] (${toolId})`);
+              try {
+                return { ...part, input: JSON.parse(part.input) };
+              } catch {
+                // If we can't parse the input, replace with an empty object to prevent API errors.
+                // The tool call was already broken (malformed JSON from the LLM), so this is
+                // the safest recovery — the API won't reject the request, and the tool result
+                // (which is likely an error) still carries forward.
+                console.warn(`[middleware] Unparseable input for ${toolId}, replacing with empty object`);
+                return { ...part, input: {} };
+              }
+            }
+            return part;
+          }),
+        };
+      }),
+    };
+    if (fixCount > 0) {
+      console.warn(`[middleware] Fixed ${fixCount} string tool-call inputs`);
+    }
+    return result;
+  },
+};
 
 /**
  * Resolve a model shorthand or config to a model instance
@@ -32,7 +88,10 @@ export function getModel(
       baseURL: 'https://api.anthropic.com/v1',
     });
 
-    return anthropic(modelId);
+    return wrapLanguageModel({
+      model: anthropic(modelId),
+      middleware: sanitizeToolInputsMiddleware,
+    });
   }
 
   // Handle full config
@@ -43,7 +102,10 @@ export function getModel(
       apiKey: apiKey || process.env.ANTHROPIC_API_KEY,
       baseURL: 'https://api.anthropic.com/v1',
     });
-    return anthropic(model);
+    return wrapLanguageModel({
+      model: anthropic(model),
+      middleware: sanitizeToolInputsMiddleware,
+    });
   }
 
   // Add other providers here as needed

--- a/examples/health-coach/lib/agents/registry.ts
+++ b/examples/health-coach/lib/agents/registry.ts
@@ -36,7 +36,7 @@ export const workflowRegistry: Record<string, RegisteredWorkflow> = {
     workflow: coachingWorkflow,
     tools: coachingTools,
     description:
-      'Full coaching flow: capture your goal, gather your profile, safety check, and generate a personalized training plan',
+      'Conversational coaching: understands your goal, assesses your fitness, and builds a personalized training plan',
     icon: 'activity',
     label: 'Coaching',
   },

--- a/examples/health-coach/lib/agents/registry.ts
+++ b/examples/health-coach/lib/agents/registry.ts
@@ -36,7 +36,7 @@ export const workflowRegistry: Record<string, RegisteredWorkflow> = {
     workflow: coachingWorkflow,
     tools: coachingTools,
     description:
-      'Conversational coaching: understands your goal, assesses your fitness, and builds a personalized training plan',
+      'Conversational coaching with a living training plan that evolves as you share more',
     icon: 'activity',
     label: 'Coaching',
   },

--- a/examples/health-coach/lib/agents/types.ts
+++ b/examples/health-coach/lib/agents/types.ts
@@ -96,8 +96,13 @@ export interface StateConfig {
   /** Tool names available in this state */
   tools: string[];
 
-  /** Tool choice strategy for this state */
-  toolChoice?: ToolChoiceConfig;
+  /**
+   * Tool choice strategy for this state.
+   * Can be a static value or a function that receives the current context.
+   * Use a function when tool choice depends on runtime state (e.g., force
+   * 'required' when the coordinator determines a document action is needed).
+   */
+  toolChoice?: ToolChoiceConfig | ((context: WorkflowContext) => ToolChoiceConfig);
 
   /**
    * System instructions for this state.
@@ -258,6 +263,9 @@ export interface StatefulAgent<TStates extends string = string> {
 
   /** Stream a response (returns a Response for use with fetch-based clients) */
   stream(params: AgentCallParams): Promise<Response>;
+
+  /** Stream returning a ReadableStream (for merging into createUIMessageStream) */
+  streamUI(params: AgentCallParams): Promise<ReadableStream>;
 
   /** Get current workflow context */
   getContext(): WorkflowContext;

--- a/examples/health-coach/lib/ai/deferred-data-stream.ts
+++ b/examples/health-coach/lib/ai/deferred-data-stream.ts
@@ -1,0 +1,43 @@
+/**
+ * Deferred DataStreamWriter
+ *
+ * Proxy that queues writes until a real DataStreamWriter is attached.
+ * Solves the timing problem: artifact tools are created at request time
+ * but the DataStreamWriter only exists inside createUIMessageStream's
+ * execute callback.
+ */
+
+import type { DataStreamWriter } from '../artifacts/types';
+
+export function createDeferredDataStream(): {
+  proxy: DataStreamWriter;
+  attach: (realWriter: DataStreamWriter) => void;
+} {
+  let realWriter: DataStreamWriter | null = null;
+  let attached = false;
+  const queue: Array<Parameters<DataStreamWriter['write']>[0]> = [];
+
+  const proxy: DataStreamWriter = {
+    write: (data) => {
+      if (realWriter) {
+        realWriter.write(data);
+      } else {
+        queue.push(data);
+      }
+    },
+  };
+
+  const attach = (writer: DataStreamWriter) => {
+    if (attached) {
+      throw new Error('DeferredDataStream: attach() called twice — this is a bug');
+    }
+    attached = true;
+    realWriter = writer;
+    for (const data of queue) {
+      realWriter.write(data);
+    }
+    queue.length = 0;
+  };
+
+  return { proxy, attach };
+}

--- a/examples/health-coach/lib/ai/tools/getDocument.ts
+++ b/examples/health-coach/lib/ai/tools/getDocument.ts
@@ -1,0 +1,68 @@
+/**
+ * getDocument Tool
+ *
+ * AI tool for reading existing documents.
+ * Gives the agent visibility into artifact content — the equivalent
+ * of a "Read" tool for documents. Without this, the agent can write
+ * to artifacts but can't verify or reference what they contain.
+ */
+
+import { tool } from 'ai';
+import { z } from 'zod';
+import { getDocumentById } from '../../db/queries';
+
+/**
+ * Props for getDocument tool factory
+ */
+interface GetDocumentToolProps {
+  /** User ID for document ownership scoping */
+  userId: string;
+}
+
+/**
+ * Create the getDocument tool
+ * Factory function that takes userId for DB scoping
+ */
+export function getDocumentTool({ userId }: GetDocumentToolProps) {
+  return tool({
+    description: `Read the current content of a document by its ID.
+Use this when you need to:
+- Verify what a document actually contains after creating or updating it
+- Reference specific details from a document when responding to user feedback
+- Check if a previous update was applied correctly
+
+You need the document ID from a previous createDocument or updateDocument call.`,
+    inputSchema: z.object({
+      id: z
+        .string()
+        .describe('The ID of the document to read'),
+    }),
+    execute: async ({ id }: { id: string }) => {
+      const doc = await getDocumentById(id, userId);
+      if (!doc) {
+        return {
+          id,
+          error: `Document with ID ${id} not found.`,
+        };
+      }
+
+      return {
+        id: doc.id,
+        title: doc.title,
+        kind: doc.kind,
+        content: doc.content,
+      };
+    },
+  });
+}
+
+/**
+ * Tool result type
+ */
+export interface GetDocumentResult {
+  id: string;
+  title?: string;
+  kind?: string;
+  content?: string;
+  error?: string;
+}

--- a/examples/health-coach/lib/ai/tools/index.ts
+++ b/examples/health-coach/lib/ai/tools/index.ts
@@ -15,6 +15,8 @@ export { createDocumentTool, artifactKinds } from './createDocument';
 export type { CreateDocumentResult } from './createDocument';
 export { updateDocumentTool } from './updateDocument';
 export type { UpdateDocumentResult } from './updateDocument';
+export { getDocumentTool } from './getDocument';
+export type { GetDocumentResult } from './getDocument';
 
 // Code execution tool
 export { executeCodeTool } from './executeCode';

--- a/examples/health-coach/lib/ai/tools/updateDocument.ts
+++ b/examples/health-coach/lib/ai/tools/updateDocument.ts
@@ -21,13 +21,20 @@ interface UpdateDocumentToolProps {
   apiKey: string;
   /** User ID for document ownership */
   userId: string;
+  /**
+   * Optional callback that provides pre-built content (e.g., from ASSESS's planDraft).
+   * When the LLM doesn't provide explicit `content` and this returns a non-null string,
+   * that string is used as the replacement content — bypassing LLM generation without
+   * requiring the LLM to echo large payloads in tool call arguments.
+   */
+  planDraftProvider?: () => string | null;
 }
 
 /**
  * Create the updateDocument tool
  * Factory function that takes dataStream context
  */
-export function updateDocumentTool({ dataStream, apiKey, userId }: UpdateDocumentToolProps) {
+export function updateDocumentTool({ dataStream, apiKey, userId, planDraftProvider }: UpdateDocumentToolProps) {
   return tool({
     description: `Update an existing document with new content based on user instructions.
 Use this tool when the user asks you to:
@@ -44,13 +51,19 @@ You need the document ID from a previous createDocument call.`,
       description: z
         .string()
         .describe('What changes to make to the document'),
+      content: z
+        .string()
+        .optional()
+        .describe('Pre-built replacement content (e.g., JSON). When provided, replaces document content directly without LLM generation.'),
     }),
     execute: async ({
       id,
       description,
+      content: prebuiltContent,
     }: {
       id: string;
       description: string;
+      content?: string;
     }) => {
       // Fetch document from database (scoped by userId)
       const existingDoc = await getDocumentById(id, userId);
@@ -118,18 +131,33 @@ You need the document ID from a previous createDocument call.`,
         transient: true,
       });
 
-      // Get the appropriate handler and generate updated content
-      const handler = getDocumentHandler(kind);
-      if (!handler) {
-        throw new Error(`No document handler found for kind: ${kind}`);
-      }
+      let updatedContent: string;
 
-      const updatedContent = await handler.onUpdateDocument({
-        document: { id, title, content },
-        description,
-        dataStream: wrappedDataStream,
-        apiKey,
-      });
+      // Resolve content: explicit content > planDraftProvider > handler LLM
+      const resolvedContent = prebuiltContent || (kind === 'training-block' ? planDraftProvider?.() : null);
+
+      if (resolvedContent) {
+        // Content bypass: stream pre-built content directly, skip handler LLM
+        wrappedDataStream.write({
+          type: 'data-codeDelta',
+          data: resolvedContent,
+          transient: true,
+        });
+        updatedContent = resolvedContent;
+      } else {
+        // Fallback: use handler's LLM generation
+        const handler = getDocumentHandler(kind);
+        if (!handler) {
+          throw new Error(`No document handler found for kind: ${kind}`);
+        }
+
+        updatedContent = await handler.onUpdateDocument({
+          document: { id, title, content },
+          description,
+          dataStream: wrappedDataStream,
+          apiKey,
+        });
+      }
 
       // Save updated document to database
       try {

--- a/packages/agents/src/createStatefulAgent.ts
+++ b/packages/agents/src/createStatefulAgent.ts
@@ -266,6 +266,11 @@ export function createStatefulAgent<TStates extends string>(
         internalContext.initialPrompt = params.prompt;
       }
 
+      // Store messages so prepareStep/instructions can access conversation history
+      if (params.messages) {
+        internalContext.messages = params.messages;
+      }
+
       // Call the agent with streaming
       // Note: prompt and messages are mutually exclusive
       // Convert UI messages to model messages format (parts -> content)

--- a/packages/agents/src/types.ts
+++ b/packages/agents/src/types.ts
@@ -264,6 +264,9 @@ export interface StatefulAgent<TStates extends string = string> {
   /** Stream a response (returns a Response for use with fetch-based clients) */
   stream(params: AgentCallParams): Promise<Response>;
 
+  /** Stream returning a ReadableStream (for merging into createUIMessageStream) */
+  streamUI(params: AgentCallParams): Promise<ReadableStream>;
+
   /** Get current workflow context */
   getContext(): WorkflowContext;
 


### PR DESCRIPTION
## Summary

Replaces the linear 6-state coaching pipeline with a looping 3+2 architecture that better matches natural conversation flow. Fixes #36.

**Architecture change:**
- **Before:** GOAL_CAPTURE → ANALYST → INTAKE → SAFETY → PLAN → PRESENT (rigid pipeline, states fight conversation flow)
- **After:** EXTRACT → ASSESS → RESPOND loop (each user message triggers all 3), with PLAN → PRESENT exit when ready

**Key improvements:**
- Each state has a focused 3-5 sentence prompt instead of a full page
- Safety flags use `{flag, acknowledged}` pattern — addressed once, then folded into context
- Deterministic `getResponseDirective()` is the single source of truth for RESPOND behavior
- Correct gap analysis ("27 seconds to drop" not "dropped 27 seconds") via isolated ASSESS state
- No more "functions that don't exist" leaks — tool sets are perfectly separated per state

**Bug fixes:**
- `wrapLanguageModel` middleware fixes AI SDK bug where `tool_use.input` is stringified during multi-step streaming
- `createStatefulAgent` now stores messages in context during `stream()` for instruction access
- `parseIfString` defensive helper for DB-loaded tool parts

## Known limitations (follow-up work)
- Plan generates as chat text, not as a `training-block` artifact
- Plan generation requires all data before starting (no early draft)
- Haiku sometimes ignores `beginPlan` tool call directive (toolChoice: auto)

## Test plan
- [x] Fresh conversation flows through goal → fitness → motivation → schedule → plan
- [x] Gap analysis computes correctly (27s from 4:47 to 4:20)
- [x] Safety flags acknowledged and don't block plan generation
- [x] No crashes from stringified tool inputs over 5+ rounds
- [x] TypeScript compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)